### PR TITLE
update version to 0.1.4 and sync primerj

### DIFF
--- a/primer-android/AndroidManifest.xml
+++ b/primer-android/AndroidManifest.xml
@@ -4,7 +4,7 @@
     package="net.bither"
     android:installLocation="internalOnly"
     android:versionCode="1"
-    android:versionName="0.1.3alpha">
+    android:versionName="0.1.4alpha">
 
     <uses-sdk
         android:minSdkVersion="9"


### PR DESCRIPTION
The abandoned peers cannot be retrieved. This may result in no peers finally, which should be avoided and has been fixed in this pr.