### PR TITLE
new incoming transaction not shown on account detail page

### DIFF
--- a/primer-android/src/net/bither/activity/hot/AddressDetailActivity.java
+++ b/primer-android/src/net/bither/activity/hot/AddressDetailActivity.java
@@ -188,6 +188,7 @@ public class AddressDetailActivity extends SwipeRightFragmentActivity implements
                 item.onResume();
             }
         }
+        loadData();
     }
 
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {


### PR DESCRIPTION
transaction-detail page does not update when the primer is not active on the android system