### PR TITLE
Fix testnet private key wif

### DIFF
--- a/primer-android/src/net/bither/rawprivatekey/RawPrivateKeyBinaryFragment.java
+++ b/primer-android/src/net/bither/rawprivatekey/RawPrivateKeyBinaryFragment.java
@@ -139,7 +139,7 @@ public class RawPrivateKeyBinaryFragment extends Fragment implements IDialogPass
                 ECKey key = new ECKey(value, null, true);
                 final String address = Utils.toAddress(key.getPubKeyHash());
                 final SecureCharSequence privateKey = new DumpedPrivateKey(key.getPrivKeyBytes(),
-                        true).toSecureCharSequence();
+                        true, Utils.getNetType()).toSecureCharSequence();
                 Utils.wipeBytes(data);
                 key.clearPrivateKey();
                 ThreadUtil.runOnMainThread(new Runnable() {

--- a/primer-android/src/net/bither/rawprivatekey/RawPrivateKeyDiceFragment.java
+++ b/primer-android/src/net/bither/rawprivatekey/RawPrivateKeyDiceFragment.java
@@ -140,7 +140,7 @@ public class RawPrivateKeyDiceFragment extends Fragment implements IDialogPasswo
                 ECKey key = new ECKey(value, null, true);
                 final String address = Utils.toAddress(key.getPubKeyHash());
                 final SecureCharSequence privateKey = new DumpedPrivateKey(key.getPrivKeyBytes(),
-                        true).toSecureCharSequence();
+                        true, Utils.getNetType()).toSecureCharSequence();
                 Utils.wipeBytes(data);
                 key.clearPrivateKey();
                 ThreadUtil.runOnMainThread(new Runnable() {


### PR DESCRIPTION
Fix bip38 handling for unit tests
NOTE: earlier TESTNET private key exports are invalid
NOTE: MAINNET private key exports NOT impacted by this issue

Bip38 unit tests now pass.