### PR TITLE
Additional transaction sending error messages

### DIFF
--- a/primer-android/res/values/strings.xml
+++ b/primer-android/res/values/strings.xml
@@ -115,6 +115,8 @@
     <string name="send_failed_dust_out_put">Send failed. Sending coins this few will be ignored.</string>
     <string name="send_failed_pendding">Send failed. %s XPM to be confirmed.\nPlease wait for another confirmation.</string>
     <string name="send_failed_max_tx_size">Send failed. Transaction size is to large.\nPlease reduce amount.</string>
+    <string name="send_failed_build_tx">Send failed at transaction assembly.</string>
+    <string name="send_failed_verify_tx">Send failed at transaction verification.</string>
     <string name="send_coins_fragment_sending_address_label">From</string>
     <string name="send_coins_fragment_receiving_address_label">Pay to</string>
     <string name="send_coins_fragment_amount_label">Amount to pay</string>

--- a/primer-android/src/net/bither/runnable/CompleteTransactionRunnable.java
+++ b/primer-android/src/net/bither/runnable/CompleteTransactionRunnable.java
@@ -195,8 +195,8 @@ public class CompleteTransactionRunnable extends BaseRunnable {
         try {
             Tx tx = wallet.buildTx(amount, toAddress, changeAddress, coin);
             if (tx == null) {
-                obtainMessage(HandlerMessage.MSG_FAILURE, PrimerApplication.mContext.getString(R
-                        .string.send_failed));
+                obtainMessage(HandlerMessage.MSG_FAILURE,
+                    PrimerApplication.mContext.getString(R.string.send_failed_build_tx));
                 return;
             }
             String outAddress = tx.getFirstOutAddressOtherThanChange(changeAddress);
@@ -223,7 +223,8 @@ public class CompleteTransactionRunnable extends BaseRunnable {
                     password.wipe();
                 }
                 if (!tx.verifySignatures()) {
-                    obtainMessage(HandlerMessage.MSG_FAILURE, getMessageFromException(null));
+                    obtainMessage(HandlerMessage.MSG_FAILURE,
+                        PrimerApplication.mContext.getString(R.string.send_failed_verify_tx));
                     return;
                 }
             }


### PR DESCRIPTION
Sync with primerj
Allow user to see amount short when sending less than balance
Respect fee precision setting when sending full balance