### PR TITLE
Allow send while wallet is behind nodes in height

### DIFF
--- a/primer-android/src/net/bither/service/BlockchainService.java
+++ b/primer-android/src/net/bither/service/BlockchainService.java
@@ -270,7 +270,7 @@ public class BlockchainService extends android.app.Service {
             if (mode == PrimerjSettings.AppMode.COLD) {
                 return;
             }
-            final boolean hasEverything = hasConnectivity && hasStorage;
+            final boolean hasEverything = hasStorage;
             NetworkUtil.NetworkType networkType = NetworkUtil.isConnectedType();
             boolean networkIsAvailadble = (!AppSharedPreference.getInstance().getSyncBlockOnlyWifi())
                     || (networkType == NetworkUtil.NetworkType.Wifi);

--- a/primer-android/src/net/bither/service/BlockchainService.java
+++ b/primer-android/src/net/bither/service/BlockchainService.java
@@ -220,7 +220,7 @@ public class BlockchainService extends android.app.Service {
     }
 
     private final BroadcastReceiver connectivityReceiver = new BroadcastReceiver() {
-        private boolean hasConnectivity;
+        private boolean hasConnectivity = true;
         private boolean hasStorage = true;
 
         @Override
@@ -270,7 +270,7 @@ public class BlockchainService extends android.app.Service {
             if (mode == PrimerjSettings.AppMode.COLD) {
                 return;
             }
-            final boolean hasEverything = hasStorage;
+            final boolean hasEverything = hasConnectivity && hasStorage;
             NetworkUtil.NetworkType networkType = NetworkUtil.isConnectedType();
             boolean networkIsAvailadble = (!AppSharedPreference.getInstance().getSyncBlockOnlyWifi())
                     || (networkType == NetworkUtil.NetworkType.Wifi);

--- a/primer-android/src/net/bither/util/SendUtil.java
+++ b/primer-android/src/net/bither/util/SendUtil.java
@@ -22,7 +22,7 @@ public class SendUtil {
             return false;
         }
         long displayLastBlockHeight = PeerManager.instance().getConnectedPeers().get(0).getDisplayLastBlockHeight();
-        if (PeerManager.instance().getLastBlockHeight() < displayLastBlockHeight) {
+        if (PeerManager.instance().getLastBlockHeight() < displayLastBlockHeight-2) {
             DropdownMessage.showDropdownMessage(activity, activity.getString(R.string.tip_sync_block_height, displayLastBlockHeight - PeerManager.instance().getLastBlockHeight()));
             return false;
         }

--- a/primer-android/src/net/bither/util/SendUtil.java
+++ b/primer-android/src/net/bither/util/SendUtil.java
@@ -21,11 +21,6 @@ public class SendUtil {
             DropdownMessage.showDropdownMessage(activity, R.string.tip_no_peers_connected);
             return false;
         }
-        long displayLastBlockHeight = PeerManager.instance().getConnectedPeers().get(0).getDisplayLastBlockHeight();
-        if (PeerManager.instance().getLastBlockHeight() < displayLastBlockHeight-2) {
-            DropdownMessage.showDropdownMessage(activity, activity.getString(R.string.tip_sync_block_height, displayLastBlockHeight - PeerManager.instance().getLastBlockHeight()));
-            return false;
-        }
         return true;
     }
 }


### PR DESCRIPTION
ConnectivityManager.EXTRA_NO_CONNECTIVITY may be set twice at start, one true and one false (default). If the "true" thread executes slower than "false" thread, the PeerManager thread would be stopped mistakenly. 